### PR TITLE
fix: stray comma in generated files

### DIFF
--- a/.changeset/afraid-seas-trade.md
+++ b/.changeset/afraid-seas-trade.md
@@ -1,0 +1,7 @@
+---
+"@gamesome/core-font": patch
+"@gamesome/astro-font": patch
+"@gamesome/style-dictionary-font": patch
+---
+
+Fix issue #10 (stray commas in output) by correcting how `@font-face` CSS is assembled when multiple font families are configured.

--- a/packages/core-font/__test__/generateCss.test.ts
+++ b/packages/core-font/__test__/generateCss.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
+import { transform } from "lightningcss";
 import { parsedFamilies } from "../src/normaliseOptions";
 import { generateCss } from "../src/generateCss";
+import type { FontFamily } from "../src/types";
 
 import fs from "fs";
 import path from "path";
@@ -41,7 +43,37 @@ const dmSansVariable = fs
 		};
 	}, {});
 
+const expectLightningCssToProcess = (css: string) => {
+	expect(() =>
+		transform({
+			filename: "test.css",
+			code: Buffer.from(css),
+			minify: false,
+		})
+	).not.toThrow();
+};
+
+const expectLightningCssToThrow = (css: string) => {
+	expect(() =>
+		transform({
+			filename: "test.css",
+			code: Buffer.from(css),
+			minify: false,
+		})
+	).toThrow();
+};
+
 describe("generateCss", () => {
+	it("should reject invalid css in lightningcss", () => {
+		expectLightningCssToThrow(`a { color red; }`);
+	});
+
+	it("should reject stray commas between @font-face blocks in lightningcss", () => {
+		expectLightningCssToThrow(
+			`@font-face { font-family: "One"; src: url(one.woff2); }, @font-face { font-family: "Two"; src: url(two.woff2); }`
+		);
+	});
+
 	it("should throw without families", async () => {
 		await expect(
 			generateCss({
@@ -55,6 +87,7 @@ describe("generateCss", () => {
 		const families = parsedFamilies([
 			{
 				name: "Rubik Variable",
+				type: "sans-serif",
 				imports: [
 					"@fontsource-variable/rubik/wght.css",
 					"@fontsource-variable/rubik/wght-italic.css",
@@ -69,6 +102,8 @@ describe("generateCss", () => {
 			},
 		});
 
+		expectLightningCssToProcess(result.css);
+
 		expect(result.css).toBe(
 			`html{font-family:"Rubik Variable","Rubik Variable Fallback: Helvetica","Rubik Variable Fallback: Helvetica Neue","Rubik Variable Fallback: Arial",ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji"!important}@font-face{font-family:'Rubik Variable';font-style:italic;font-display:swap;font-weight:300 900;src:url(./files/rubik-arabic-wght-italic.woff2) format('woff2-variations');unicode-range:U+0600-06FF,U+0750-077F,U+0870-088E,U+0890-0891,U+0898-08E1,U+08E3-08FF,U+200C-200E,U+2010-2011,U+204F,U+2E41,U+FB50-FDFF,U+FE70-FE74,U+FE76-FEFC}@font-face{font-family:'Rubik Variable';font-style:italic;font-display:swap;font-weight:300 900;src:url(./files/rubik-cyrillic-ext-wght-italic.woff2) format('woff2-variations');unicode-range:U+0460-052F,U+1C80-1C88,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F}@font-face{font-family:'Rubik Variable';font-style:italic;font-display:swap;font-weight:300 900;src:url(./files/rubik-cyrillic-wght-italic.woff2) format('woff2-variations');unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116}@font-face{font-family:'Rubik Variable';font-style:italic;font-display:swap;font-weight:300 900;src:url(./files/rubik-hebrew-wght-italic.woff2) format('woff2-variations');unicode-range:U+0590-05FF,U+200C-2010,U+20AA,U+25CC,U+FB1D-FB4F}@font-face{font-family:'Rubik Variable';font-style:italic;font-display:swap;font-weight:300 900;src:url(./files/rubik-latin-ext-wght-italic.woff2) format('woff2-variations');unicode-range:U+0100-02AF,U+0304,U+0308,U+0329,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20CF,U+2113,U+2C60-2C7F,U+A720-A7FF}@font-face{font-family:'Rubik Variable';font-style:italic;font-display:swap;font-weight:300 900;src:url(./files/rubik-latin-wght-italic.woff2) format('woff2-variations');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+2074,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}@font-face{font-family:"Rubik Variable";font-style:normal;font-display:swap;font-weight:300 900;src:url(./files/rubik-arabic-wght-normal.woff2) format("woff2-variations");unicode-range:U+0600-06FF,U+0750-077F,U+0870-088E,U+0890-0891,U+0898-08E1,U+08E3-08FF,U+200C-200E,U+2010-2011,U+204F,U+2E41,U+FB50-FDFF,U+FE70-FE74,U+FE76-FEFC}@font-face{font-family:"Rubik Variable";font-style:normal;font-display:swap;font-weight:300 900;src:url(./files/rubik-cyrillic-ext-wght-normal.woff2) format("woff2-variations");unicode-range:U+0460-052F,U+1C80-1C88,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F}@font-face{font-family:"Rubik Variable";font-style:normal;font-display:swap;font-weight:300 900;src:url(./files/rubik-cyrillic-wght-normal.woff2) format("woff2-variations");unicode-range:U+0301,U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116}@font-face{font-family:"Rubik Variable";font-style:normal;font-display:swap;font-weight:300 900;src:url(./files/rubik-hebrew-wght-normal.woff2) format("woff2-variations");unicode-range:U+0590-05FF,U+200C-2010,U+20AA,U+25CC,U+FB1D-FB4F}@font-face{font-family:"Rubik Variable";font-style:normal;font-display:swap;font-weight:300 900;src:url(./files/rubik-latin-ext-wght-normal.woff2) format("woff2-variations");unicode-range:U+0100-02AF,U+0304,U+0308,U+0329,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20CF,U+2113,U+2C60-2C7F,U+A720-A7FF}@font-face{font-family:"Rubik Variable";font-style:normal;font-display:swap;font-weight:300 900;src:url(./files/rubik-latin-wght-normal.woff2) format("woff2-variations");unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+2074,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}@font-face{font-family:"Rubik Variable Fallback: Helvetica";src:local('Helvetica');font-display:swap;ascent-override:89.0649%;descent-override:23.8141%;size-adjust:104.9796%}@font-face{font-family:"Rubik Variable Fallback: Helvetica Neue";src:local('Helvetica Neue'),local('HelveticaNeue');font-display:swap;ascent-override:89.9038%;descent-override:24.0385%;line-gap-override:0%;size-adjust:104%}@font-face{font-family:"Rubik Variable Fallback: Arial";src:local('Arial'),local('ArialMT');font-display:swap;ascent-override:89.0649%;descent-override:23.8141%;line-gap-override:0%;size-adjust:104.9796%}@font-face{font-family:"Rubik Variable Fallback: Helvetica";src:local('Helvetica Bold');font-display:swap;font-weight:700;ascent-override:89.5772%;descent-override:23.9511%;size-adjust:104.3792%}@font-face{font-family:"Rubik Variable Fallback: Helvetica Neue";src:local('Helvetica Neue Bold');font-display:swap;font-weight:700;ascent-override:89.5808%;descent-override:23.9521%;line-gap-override:0%;size-adjust:104.375%}@font-face{font-family:"Rubik Variable Fallback: Arial";src:local('Arial Bold');font-display:swap;font-weight:700;ascent-override:89.5772%;descent-override:23.9511%;line-gap-override:0%;size-adjust:104.3792%}`
 		);
@@ -78,6 +113,7 @@ describe("generateCss", () => {
 		const families = parsedFamilies([
 			{
 				name: "Rubik Variable",
+				type: "sans-serif",
 				imports: ["@fontsource-variable/rubik/wght.css"],
 			},
 		]);
@@ -90,6 +126,7 @@ describe("generateCss", () => {
 			prettifyOutput: true,
 		});
 
+		expectLightningCssToProcess(result.css);
 		expect(result.css).not.toContain("undefined");
 		expect(result.css).toContain("\n");
 	});
@@ -98,6 +135,7 @@ describe("generateCss", () => {
 		const families = parsedFamilies([
 			{
 				name: "DM Sans Variable",
+				type: "sans-serif",
 				imports: [
 					"@fontsource-variable/dm-sans/wght.css",
 					"@fontsource-variable/dm-sans/wght-italic.css",
@@ -112,15 +150,100 @@ describe("generateCss", () => {
 			},
 		});
 
+		expectLightningCssToProcess(result.css);
+
 		expect(result.css).toBe(
 			`html{font-family:"DM Sans Variable","DM Sans Variable Fallback: Helvetica","DM Sans Variable Fallback: Helvetica Neue","DM Sans Variable Fallback: Arial",ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji"!important}@font-face{font-family:'DM Sans Variable';font-style:italic;font-display:swap;font-weight:100 1000;src:url(./files/dm-sans-latin-ext-wght-italic.woff2) format('woff2-variations');unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF}@font-face{font-family:'DM Sans Variable';font-style:italic;font-display:swap;font-weight:100 1000;src:url(./files/dm-sans-latin-wght-italic.woff2) format('woff2-variations');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}@font-face{font-family:'DM Sans Variable';font-style:normal;font-display:swap;font-weight:100 1000;src:url(./files/dm-sans-latin-ext-wght-normal.woff2) format('woff2-variations');unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF}@font-face{font-family:'DM Sans Variable';font-style:normal;font-display:swap;font-weight:100 1000;src:url(./files/dm-sans-latin-wght-normal.woff2) format('woff2-variations');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}@font-face{font-family:"DM Sans Variable Fallback: Helvetica";src:local('Helvetica');font-display:swap;ascent-override:94.9001%;descent-override:29.6563%;size-adjust:104.531%}@font-face{font-family:"DM Sans Variable Fallback: Helvetica Neue";src:local('Helvetica Neue'),local('HelveticaNeue');font-display:swap;ascent-override:95.794%;descent-override:29.9356%;line-gap-override:0%;size-adjust:103.5556%}@font-face{font-family:"DM Sans Variable Fallback: Arial";src:local('Arial'),local('ArialMT');font-display:swap;ascent-override:94.9001%;descent-override:29.6563%;line-gap-override:0%;size-adjust:104.531%}@font-face{font-family:"DM Sans Variable Fallback: Helvetica";src:local('Helvetica Bold');font-display:swap;font-weight:700;ascent-override:96.5802%;descent-override:30.1813%;size-adjust:102.7125%}@font-face{font-family:"DM Sans Variable Fallback: Helvetica Neue";src:local('Helvetica Neue Bold');font-display:swap;font-weight:700;ascent-override:96.5842%;descent-override:30.1826%;line-gap-override:0%;size-adjust:102.7083%}@font-face{font-family:"DM Sans Variable Fallback: Arial";src:local('Arial Bold');font-display:swap;font-weight:700;ascent-override:96.5802%;descent-override:30.1813%;line-gap-override:0%;size-adjust:102.7125%}`
 		);
+	});
+
+	it("should handle multiple fonts", async () => {
+		const rubikFamily: FontFamily = {
+			name: "Rubik Variable",
+			type: "sans-serif",
+			imports: ["@fontsource-variable/rubik/wght.css"],
+			fallbacks: false,
+			appendFontFamilies: false,
+			applyFontFamilyToSelector: false,
+		};
+		const dmSansFamily: FontFamily = {
+			name: "DM Sans Variable",
+			type: "sans-serif",
+			imports: ["@fontsource-variable/dm-sans/wght.css"],
+			fallbacks: false,
+			appendFontFamilies: false,
+			applyFontFamilyToSelector: false,
+		};
+
+		const rubikResult = await generateCss({
+			families: parsedFamilies([rubikFamily]),
+			fontFaceDeclarations: {
+				rubik_variable: {
+					rubik_wght: rubikVariable.rubik_wght,
+				},
+			},
+		});
+
+		const dmSansResult = await generateCss({
+			families: parsedFamilies([dmSansFamily]),
+			fontFaceDeclarations: {
+				dm_sans_variable: {
+					dm_sans_wght: dmSansVariable.dm_sans_wght,
+				},
+			},
+		});
+
+		const combinedResult = await generateCss({
+			families: parsedFamilies([rubikFamily, dmSansFamily]),
+			fontFaceDeclarations: {
+				rubik_variable: {
+					rubik_wght: rubikVariable.rubik_wght,
+				},
+				dm_sans_variable: {
+					dm_sans_wght: dmSansVariable.dm_sans_wght,
+				},
+			},
+		});
+
+		expectLightningCssToProcess(rubikResult.css);
+		expectLightningCssToProcess(dmSansResult.css);
+		expectLightningCssToProcess(combinedResult.css);
+		expect(combinedResult.css).toBe(`${rubikResult.css}${dmSansResult.css}`);
+	});
+
+	it("should generate font faces without applying them when applyFontFamilyToSelector is false", async () => {
+		const families = parsedFamilies([
+			{
+				name: "Rubik Variable",
+				type: "sans-serif",
+				imports: ["@fontsource-variable/rubik/wght.css"],
+				fallbacks: false,
+				appendFontFamilies: false,
+				applyFontFamilyToSelector: false,
+			},
+		]);
+
+		const result = await generateCss({
+			families,
+			fontFaceDeclarations: {
+				rubik_variable: {
+					rubik_wght: rubikVariable.rubik_wght,
+				},
+			},
+		});
+
+		expectLightningCssToProcess(result.css);
+		expect(result.css).toContain('font-family:"Rubik Variable"');
+		expect(result.css).not.toContain("html{font-family:");
+		expect(result.css).not.toContain(".font-serif{font-family:");
+		expect(result.css).not.toContain(".font-sans{font-family:");
 	});
 
 	it("should use supported custom bold weights when Capsize exposes that variant", async () => {
 		const families = parsedFamilies([
 			{
 				name: "DM Sans Variable",
+				type: "sans-serif",
 				imports: ["@fontsource-variable/dm-sans/wght.css"],
 				fallbacks: [
 					{
@@ -149,6 +272,7 @@ describe("generateCss", () => {
 		const families = parsedFamilies([
 			{
 				name: "DM Sans Variable",
+				type: "sans-serif",
 				imports: ["@fontsource-variable/dm-sans/wght.css"],
 				fallbacks: [
 					{
@@ -184,6 +308,7 @@ describe("generateCss", () => {
 		const families = parsedFamilies([
 			{
 				name: "DM Sans Variable",
+				type: "sans-serif",
 				imports: ["@fontsource-variable/dm-sans/wght.css"],
 				fallbacks: [
 					{

--- a/packages/core-font/__test__/normaliseOptions.test.ts
+++ b/packages/core-font/__test__/normaliseOptions.test.ts
@@ -6,7 +6,9 @@ import {
 	_parsedFontImport,
 	_parsedPreloads,
 	_parsedSelector,
+	parsedFamilies,
 } from "../src/normaliseOptions";
+import type { FontFamily } from "../src/types";
 
 describe("_parsedPreloads", () => {
 	it("should return default preloads if preloads is undefined and firstFontFile is true", () => {
@@ -352,6 +354,28 @@ describe("_parsedSelector", () => {
 		assert.throws(
 			() => _parsedSelector(undefined, false),
 			/@gamesome\/core-font encounterd a font family with an invalid applyFontFamilyToSelector/
+		);
+	});
+});
+
+describe("parsedFamilies", () => {
+	it("should throw if a later font family omits applyFontFamilyToSelector", () => {
+		const families: FontFamily[] = [
+			{
+				name: "Rubik Variable",
+				type: "sans-serif",
+				imports: ["@fontsource-variable/rubik/wght.css"],
+			},
+			{
+				name: "DM Sans Variable",
+				type: "sans-serif",
+				imports: ["@fontsource-variable/dm-sans/wght.css"],
+			},
+		];
+
+		assert.throws(
+			() => parsedFamilies(families),
+			/@gamesome\/core-font: you must specify applyFontFamilyToSelector for every font family after the first\./
 		);
 	});
 });

--- a/packages/core-font/package.json
+++ b/packages/core-font/package.json
@@ -27,6 +27,7 @@
 	},
 	"devDependencies": {
 		"@types/clean-css": "4.2.10",
+		"lightningcss": "1.32.0",
 		"typescript": "5.2.2",
 		"vite": "4.5.0",
 		"vite-plugin-dts": "3.6.3",

--- a/packages/core-font/src/generateCss.ts
+++ b/packages/core-font/src/generateCss.ts
@@ -252,9 +252,11 @@ export const generateCss = async (
 			`;
 		})
 		.join("\n")}
-		${Object.values(fontFaceDeclarations).map((entry) => {
-			return Object.values(entry).join("\n");
-		})}
+		${Object.values(fontFaceDeclarations)
+			.map((entry) => {
+				return Object.values(entry).join("\n");
+			})
+			.join("\n")}
 		${allFallbackFontFaceDeclarations.join("\n")}
 		`;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: link:../../packages/astro-font
       astro:
         specifier: ^4.0.0
-        version: 4.16.19(@types/node@25.3.3)(rollup@4.59.0)(typescript@5.8.2)
+        version: 4.16.19(@types/node@25.3.3)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.8.2)
 
   examples/style-dictionary-basic:
     dependencies:
@@ -71,13 +71,13 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react':
         specifier: ^4.2.0
-        version: 4.7.0(vite@4.5.0(@types/node@25.3.3))
+        version: 4.7.0(vite@4.5.0(@types/node@25.3.3)(lightningcss@1.32.0))
       typescript:
         specifier: 5.2.2
         version: 5.2.2
       vite:
         specifier: 4.5.0
-        version: 4.5.0(@types/node@25.3.3)
+        version: 4.5.0(@types/node@25.3.3)(lightningcss@1.32.0)
 
   packages/astro-font:
     dependencies:
@@ -90,19 +90,19 @@ importers:
         version: 0.2.1(prettier-plugin-astro@0.12.0)(prettier@3.8.1)(typescript@5.2.2)
       astro:
         specifier: 3.3.2
-        version: 3.3.2(@types/node@25.3.3)(typescript@5.2.2)
+        version: 3.3.2(@types/node@25.3.3)(lightningcss@1.32.0)(typescript@5.2.2)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
       vite:
         specifier: 4.5.0
-        version: 4.5.0(@types/node@25.3.3)
+        version: 4.5.0(@types/node@25.3.3)(lightningcss@1.32.0)
       vite-plugin-dts:
         specifier: 3.6.3
-        version: 3.6.3(@types/node@25.3.3)(rollup@4.59.0)(typescript@5.2.2)(vite@4.5.0(@types/node@25.3.3))
+        version: 3.6.3(@types/node@25.3.3)(rollup@4.59.0)(typescript@5.2.2)(vite@4.5.0(@types/node@25.3.3)(lightningcss@1.32.0))
       vitest:
         specifier: 0.34.6
-        version: 0.34.6
+        version: 0.34.6(lightningcss@1.32.0)
 
   packages/core-font:
     dependencies:
@@ -119,18 +119,21 @@ importers:
       '@types/clean-css':
         specifier: 4.2.10
         version: 4.2.10
+      lightningcss:
+        specifier: 1.32.0
+        version: 1.32.0
       typescript:
         specifier: 5.2.2
         version: 5.2.2
       vite:
         specifier: 4.5.0
-        version: 4.5.0(@types/node@25.3.3)
+        version: 4.5.0(@types/node@25.3.3)(lightningcss@1.32.0)
       vite-plugin-dts:
         specifier: 3.6.3
-        version: 3.6.3(@types/node@25.3.3)(rollup@4.59.0)(typescript@5.2.2)(vite@4.5.0(@types/node@25.3.3))
+        version: 3.6.3(@types/node@25.3.3)(rollup@4.59.0)(typescript@5.2.2)(vite@4.5.0(@types/node@25.3.3)(lightningcss@1.32.0))
       vitest:
         specifier: 0.34.6
-        version: 0.34.6
+        version: 0.34.6(lightningcss@1.32.0)
 
   packages/style-dictionary-font:
     dependencies:
@@ -149,13 +152,13 @@ importers:
         version: 5.2.2
       vite:
         specifier: 4.5.0
-        version: 4.5.0(@types/node@24.11.0)
+        version: 4.5.0(@types/node@24.11.0)(lightningcss@1.32.0)
       vite-plugin-dts:
         specifier: 3.6.3
-        version: 3.6.3(@types/node@24.11.0)(rollup@4.59.0)(typescript@5.2.2)(vite@4.5.0(@types/node@24.11.0))
+        version: 3.6.3(@types/node@24.11.0)(rollup@4.59.0)(typescript@5.2.2)(vite@4.5.0(@types/node@24.11.0)(lightningcss@1.32.0))
       vitest:
         specifier: 0.34.6
-        version: 0.34.6
+        version: 0.34.6(lightningcss@1.32.0)
 
 packages:
 
@@ -2547,6 +2550,76 @@ packages:
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   load-yaml-file@0.2.0:
     resolution: {integrity: sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==}
     engines: {node: '>=6'}
@@ -3169,6 +3242,10 @@ packages:
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
@@ -4267,10 +4344,10 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@astrojs/markdown-remark@3.3.0(astro@3.3.2(@types/node@25.3.3)(typescript@5.2.2))':
+  '@astrojs/markdown-remark@3.3.0(astro@3.3.2(@types/node@25.3.3)(lightningcss@1.32.0)(typescript@5.2.2))':
     dependencies:
       '@astrojs/prism': 3.3.0
-      astro: 3.3.2(@types/node@25.3.3)(typescript@5.2.2)
+      astro: 3.3.2(@types/node@25.3.3)(lightningcss@1.32.0)(typescript@5.2.2)
       github-slugger: 2.0.0
       import-meta-resolve: 3.1.1
       mdast-util-definitions: 6.0.0
@@ -5523,7 +5600,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@4.5.0(@types/node@25.3.3))':
+  '@vitejs/plugin-react@4.7.0(vite@4.5.0(@types/node@25.3.3)(lightningcss@1.32.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -5531,7 +5608,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 4.5.0(@types/node@25.3.3)
+      vite: 4.5.0(@types/node@25.3.3)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5725,11 +5802,11 @@ snapshots:
 
   assertion-error@1.1.0: {}
 
-  astro@3.3.2(@types/node@25.3.3)(typescript@5.2.2):
+  astro@3.3.2(@types/node@25.3.3)(lightningcss@1.32.0)(typescript@5.2.2):
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/internal-helpers': 0.2.1
-      '@astrojs/markdown-remark': 3.3.0(astro@3.3.2(@types/node@25.3.3)(typescript@5.2.2))
+      '@astrojs/markdown-remark': 3.3.0(astro@3.3.2(@types/node@25.3.3)(lightningcss@1.32.0)(typescript@5.2.2))
       '@astrojs/telemetry': 3.0.3
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -5778,8 +5855,8 @@ snapshots:
       tsconfck: 3.1.6(typescript@5.2.2)
       unist-util-visit: 4.1.2
       vfile: 5.3.7
-      vite: 4.5.0(@types/node@25.3.3)
-      vitefu: 0.2.5(vite@4.5.0(@types/node@25.3.3))
+      vite: 4.5.0(@types/node@25.3.3)(lightningcss@1.32.0)
+      vitefu: 0.2.5(vite@4.5.0(@types/node@25.3.3)(lightningcss@1.32.0))
       which-pm: 2.2.0
       yargs-parser: 21.1.1
       zod: 3.21.1
@@ -5799,7 +5876,7 @@ snapshots:
       - terser
       - typescript
 
-  astro@4.16.19(@types/node@25.3.3)(rollup@4.59.0)(typescript@5.8.2):
+  astro@4.16.19(@types/node@25.3.3)(lightningcss@1.32.0)(rollup@4.59.0)(typescript@5.8.2):
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/internal-helpers': 0.4.1
@@ -5855,8 +5932,8 @@ snapshots:
       tsconfck: 3.1.6(typescript@5.8.2)
       unist-util-visit: 5.1.0
       vfile: 6.0.3
-      vite: 5.4.21(@types/node@25.3.3)
-      vitefu: 1.1.2(vite@5.4.21(@types/node@25.3.3))
+      vite: 5.4.21(@types/node@25.3.3)(lightningcss@1.32.0)
+      vitefu: 1.1.2(vite@5.4.21(@types/node@25.3.3)(lightningcss@1.32.0))
       which-pm: 3.0.1
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
@@ -6205,8 +6282,7 @@ snapshots:
 
   detect-indent@6.1.0: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   deterministic-object-hash@1.3.1: {}
 
@@ -6926,6 +7002,55 @@ snapshots:
   kleur@4.1.5: {}
 
   kolorist@1.8.0: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   load-yaml-file@0.2.0:
     dependencies:
@@ -7926,6 +8051,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   prebuild-install@7.1.3:
     dependencies:
       detect-libc: 2.1.2
@@ -8898,14 +9029,14 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@0.34.6(@types/node@25.3.3):
+  vite-node@0.34.6(@types/node@25.3.3)(lightningcss@1.32.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       mlly: 1.8.0
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 4.5.0(@types/node@25.3.3)
+      vite: 4.5.0(@types/node@25.3.3)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -8916,7 +9047,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-dts@3.6.3(@types/node@24.11.0)(rollup@4.59.0)(typescript@5.2.2)(vite@4.5.0(@types/node@24.11.0)):
+  vite-plugin-dts@3.6.3(@types/node@24.11.0)(rollup@4.59.0)(typescript@5.2.2)(vite@4.5.0(@types/node@24.11.0)(lightningcss@1.32.0)):
     dependencies:
       '@microsoft/api-extractor': 7.57.6(@types/node@24.11.0)
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
@@ -8926,13 +9057,13 @@ snapshots:
       typescript: 5.2.2
       vue-tsc: 1.8.27(typescript@5.2.2)
     optionalDependencies:
-      vite: 4.5.0(@types/node@24.11.0)
+      vite: 4.5.0(@types/node@24.11.0)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-plugin-dts@3.6.3(@types/node@25.3.3)(rollup@4.59.0)(typescript@5.2.2)(vite@4.5.0(@types/node@25.3.3)):
+  vite-plugin-dts@3.6.3(@types/node@25.3.3)(rollup@4.59.0)(typescript@5.2.2)(vite@4.5.0(@types/node@25.3.3)(lightningcss@1.32.0)):
     dependencies:
       '@microsoft/api-extractor': 7.57.6(@types/node@25.3.3)
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
@@ -8942,13 +9073,13 @@ snapshots:
       typescript: 5.2.2
       vue-tsc: 1.8.27(typescript@5.2.2)
     optionalDependencies:
-      vite: 4.5.0(@types/node@25.3.3)
+      vite: 4.5.0(@types/node@25.3.3)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite@4.5.0(@types/node@24.11.0):
+  vite@4.5.0(@types/node@24.11.0)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.18.20
       postcss: 8.5.6
@@ -8956,8 +9087,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.11.0
       fsevents: 2.3.3
+      lightningcss: 1.32.0
 
-  vite@4.5.0(@types/node@25.3.3):
+  vite@4.5.0(@types/node@25.3.3)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.18.20
       postcss: 8.5.6
@@ -8965,25 +9097,27 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.3.3
       fsevents: 2.3.3
+      lightningcss: 1.32.0
 
-  vite@5.4.21(@types/node@25.3.3):
+  vite@5.4.21(@types/node@25.3.3)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.5.6
+      postcss: 8.5.8
       rollup: 4.59.0
     optionalDependencies:
       '@types/node': 25.3.3
       fsevents: 2.3.3
+      lightningcss: 1.32.0
 
-  vitefu@0.2.5(vite@4.5.0(@types/node@25.3.3)):
+  vitefu@0.2.5(vite@4.5.0(@types/node@25.3.3)(lightningcss@1.32.0)):
     optionalDependencies:
-      vite: 4.5.0(@types/node@25.3.3)
+      vite: 4.5.0(@types/node@25.3.3)(lightningcss@1.32.0)
 
-  vitefu@1.1.2(vite@5.4.21(@types/node@25.3.3)):
+  vitefu@1.1.2(vite@5.4.21(@types/node@25.3.3)(lightningcss@1.32.0)):
     optionalDependencies:
-      vite: 5.4.21(@types/node@25.3.3)
+      vite: 5.4.21(@types/node@25.3.3)(lightningcss@1.32.0)
 
-  vitest@0.34.6:
+  vitest@0.34.6(lightningcss@1.32.0):
     dependencies:
       '@types/chai': 4.3.20
       '@types/chai-subset': 1.3.6(@types/chai@4.3.20)
@@ -9006,8 +9140,8 @@ snapshots:
       strip-literal: 1.3.0
       tinybench: 2.9.0
       tinypool: 0.7.0
-      vite: 4.5.0(@types/node@25.3.3)
-      vite-node: 0.34.6(@types/node@25.3.3)
+      vite: 4.5.0(@types/node@25.3.3)(lightningcss@1.32.0)
+      vite-node: 0.34.6(@types/node@25.3.3)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
## Summary

Fixes #10 by correcting how `@font-face` CSS is assembled when multiple font families are configured.

Previously, the generated CSS interpolated an array of per-family `@font-face` blocks directly into a template literal. That caused JavaScript to join the array with commas, which produced invalid CSS between font-family groups:

```css
@font-face { ... },
@font-face { ... }
```

The implementation now joins those blocks explicitly with newlines instead.

### What Changed

- Fixed generateCss() in @gamesome/core-font so multi-family fontFaceDeclarations are joined with "\n" instead of relying on implicit array stringification.
- Added a regression test for multiple fonts.
- Added coverage for applyFontFamilyToSelector: false to verify fonts are generated without being auto-applied.
- Added coverage that parsedFamilies() throws when a later family omits applyFontFamilyToSelector.
- Added CSS validation coverage using lightningcss.
- Added a negative test confirming lightningcss rejects the stray-comma @font-face form.


### Why

The previous output was tolerated by some tooling and browsers, but it was still invalid CSS and triggered warnings in stricter validators and linters.

This change fixes the root cause and adds regression coverage around both the multi-font generation path and CSS validation behavior.